### PR TITLE
correct viewport outlines regardless of view scale

### DIFF
--- a/index.renkon
+++ b/index.renkon
@@ -1661,7 +1661,7 @@ const windowResize = Events.listener(window, "resize", evt => evt);
 const padExtentChange = ((trigger) => {
   const buttonBox = document.querySelector("#buttonBox");
   const rect = buttonBox.getBoundingClientRect();
-  return {viewId, w: window.innerWidth, h: window.innerHeight - rect.height, top: rect.height * padView.scale};
+  return {viewId, w: window.innerWidth, h: window.innerHeight - rect.height, top: rect.height};
 })(Events.or(windowResize, initialExtent));
 
 const cursorPosition = ((move) => {
@@ -3502,7 +3502,7 @@ SVG icons are created in 24x24 viewport, and converted to the data string.`],
 
     const view = {
       x: padView.x,
-      y: padView.y - extent.top,
+      y: padView.y - extent.top / padView.scale,
       w: extent.w / padView.scale,
       h: extent.h / padView.scale,
       top: extent.top,


### PR DESCRIPTION
Fixes the per-user viewport outline appearing at the wrong vertical position when zoom isn't 1.0 (about 30px off at scale 0.6, invisible at 1.0). `padExtentChange` was storing `top: rect.height * padView.scale`, which `viewports` then used as if it were pad-coords. Aligned with how `extent.w` and `extent.h` are handled — store raw screen pixels and divide by the consumer's current scale at use-site. Bonus: removes the staleness issue from `padExtentChange` only refiring on window resize / initial sync.

(summary by Claude)
